### PR TITLE
Adapt plugin to GitBook 3

### DIFF
--- a/book/plugin.js
+++ b/book/plugin.js
@@ -1,8 +1,4 @@
 require(["gitbook", "jquery"], function(gitbook, $) {
-    gitbook.events.bind("start", function(e, config) {
-
-    });
-
     gitbook.events.bind("page.change", function() {
         var $pageWrapper = $('.page-wrapper'),
         	$headers = $pageWrapper.find('h1:not(.search-results-title), h2'),

--- a/book/plugin.js
+++ b/book/plugin.js
@@ -36,12 +36,12 @@ require(["gitbook", "jquery"], function(gitbook, $) {
             });
         }
 
-        $(window).off('keyup').on("keyup", function(event) {
-            if (event.which === 188) {
-                getPrev();
-            } else if (event.which === 190) {
-                getNext();
-            }
-        });    
+        gitbook.keyboard.bind(['right'], function() {
+            getNext();
+        });
+
+        gitbook.keyboard.bind(['left'], function() {
+            getPrev();
+        });
     });
 });

--- a/book/plugin.js
+++ b/book/plugin.js
@@ -5,7 +5,7 @@ require(["gitbook", "jquery"], function(gitbook, $) {
 
     gitbook.events.bind("page.change", function() {
         var $pageWrapper = $('.page-wrapper'),
-        	$headers = $pageWrapper.find('h1, h2'),
+        	$headers = $pageWrapper.find('h1:not(.search-results-title), h2'),
         	total = $headers.length;
 
         $headers.each(function(index) {


### PR DESCRIPTION
Hello,

We will soon release [GitBook v3](https://github.com/GitbookIO/gitbook).
The plugins API has been updated, as you will see [in the GitBook 3 documentation](http://toolchain.gitbook.com/).

I'm in charge of reviewing the existing plugins for maintaining the compatibility with this new version.
We added some `<h1>` tags in the [default theme](https://github.com/GitbookIO/theme-default) to display search results. The front-end `gitbook` module also gets its own `gitbook.keyboard` submodule for keyboard events handling.

The proposed PR has been tested with the new version and makes your plugin compatible with this changes.
Let me know if you have any remarks regarding what is done, and don't forget to publish a new version if you merge it :)

When releasing a new version, you will have to upgrade the engine in your `package.json`:

``` JSON
"engines": {
    "gitbook": ">=3.0.0-pre.0"
}
```

Kind regards,
Johan
